### PR TITLE
Heights

### DIFF
--- a/Content.Shared/Physics/Components/FixturesReplaceComponent.cs
+++ b/Content.Shared/Physics/Components/FixturesReplaceComponent.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Robust.Shared.GameObjects;
+using Robust.Shared.GameStates;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Content.Shared.Physics.Components;
+
+/// <summary>
+/// Adds / removes fixtures on startup / shutdown without modifying the other fixtures on the entity. Needed for a content change.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class FixturesReplaceComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, Fixture> Fixtures = new();
+}

--- a/Content.Shared/Physics/Systems/FixturesReplaceSystem.cs
+++ b/Content.Shared/Physics/Systems/FixturesReplaceSystem.cs
@@ -1,0 +1,60 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Physics;
+using Content.Shared.Physics.Components;
+
+namespace Content.Shared.Physics.Systems;
+
+public sealed class FixturesReplaceSystem : EntitySystem
+{
+    [Dependency] private readonly FixtureSystem _fixtures = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+    private EntityQuery<FixturesComponent> _fixturesQuery;
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _fixturesQuery = GetEntityQuery<FixturesComponent>();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        SubscribeLocalEvent<FixturesReplaceComponent, ComponentStartup>(OnChangeStartup);
+        SubscribeLocalEvent<FixturesReplaceComponent, ComponentShutdown>(OnChangeShutdown);
+    }
+
+    private void OnChangeStartup(Entity<FixturesReplaceComponent> ent, ref ComponentStartup args)
+    {
+        if (!_physicsQuery.TryComp(ent, out var physics) || !_fixturesQuery.TryComp(ent, out var fixtures))
+            return;
+
+        foreach (var (id, fixture) in ent.Comp.Fixtures)
+        {
+			_fixtures.DestroyFixture(ent.Owner, id);
+			
+            _fixtures.TryCreateFixture(ent.Owner,
+                fixture.Shape,
+                id,
+                fixture.Density,
+                fixture.Hard,
+                fixture.CollisionLayer,
+                fixture.CollisionMask,
+                fixture.Friction,
+                fixture.Restitution,
+                manager: fixtures,
+                body: physics);
+        }
+
+        // TODO: Fixture creation should be handling this.
+        _physics.WakeBody(ent.Owner, manager: fixtures, body: physics);
+    }
+
+    private void OnChangeShutdown(Entity<FixturesReplaceComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var id in ent.Comp.Fixtures.Keys)
+        {
+            _fixtures.DestroyFixture(ent.Owner, id);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_hereelabs/heights.ftl
+++ b/Resources/Locale/en-US/_hereelabs/heights.ftl
@@ -1,0 +1,16 @@
+trait-category-height = Height
+
+trait-dwarf-name = Dwarven
+trait-dwarf-desc = Rock and stone. You're just like a dwarf!
+
+trait-huge-name = Huge
+trait-huge-desc = You're large and in charge. People have a hard time dragging you. Problem is, now you're a much bigger target, and you have to squeeze yourself through airlocks.
+
+trait-tall-name = Tall
+trait-tall-desc = You're taller than the average spacer!
+
+trait-short-name = Short
+trait-short-desc = You're shorter than the average spacer!
+
+trait-tiny-name = Pipsqueak
+trait-tiny-desc = You're VERY small. You can be picked up like an item, and can fit through smaller spaces, but you cant wield weapons. They're too big!

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -16,6 +16,11 @@
   # traits
   - BlackAndWhiteOverlay
   - Clumsy
+  - Tiny
+  - Dwarf
+  - Short
+  - Tall
+  - Huge
   - Hemophilia
   - ImpairedMobility
   # - LegsParalyzed (you get healed)

--- a/Resources/Prototypes/_hereelabs/Entities/Mobs/Species/rachnid.yml
+++ b/Resources/Prototypes/_hereelabs/Entities/Mobs/Species/rachnid.yml
@@ -12,6 +12,7 @@
     species: Rachnid
   - type: Hunger
   - type: Thirst
+  - type: Carriable
   - type: Tag
     tags:
     - CanPilot
@@ -67,7 +68,7 @@
   - type: TypingIndicator
     proto: spider
   - type: Spider
-    spawnWebsAsNonPlayer: false
+    spawnsWebsAsNonPlayer: false
   - type: IgnoreSpiderWeb
   - type: Inventory
     templateId: rachnid

--- a/Resources/Prototypes/_hereelabs/Traits/categories.yml
+++ b/Resources/Prototypes/_hereelabs/Traits/categories.yml
@@ -1,0 +1,4 @@
+- type: traitCategory
+  id: Height
+  name: trait-category-height
+  maxTraitPoints: 1

--- a/Resources/Prototypes/_hereelabs/Traits/quirks.yml
+++ b/Resources/Prototypes/_hereelabs/Traits/quirks.yml
@@ -1,0 +1,170 @@
+# If you add a new trait, make sure to add the corresponding component to the whitelist in \Resources\Prototypes\Entities\Mobs\Player\clone.yml so it gets copied to clones correctly!
+
+- type: trait
+  id: Tiny
+  name: trait-tiny-name
+  description: trait-tiny-desc
+  category: Height
+  cost: 1
+  components:
+  - type: WieldingBlocker
+  - type: Item
+    size: Huge
+  - type: MultiHandedItem
+  - type: ScaleVisuals
+    scale: 0.5, 0.5
+  - type: FixturesReplace
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        # they r smallest
+        density: 85
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+      flammable:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.25
+        density: 1
+        restitution: 0.0
+        mask:
+        - 221
+        layer:
+        - 0
+
+- type: trait
+  id: Dwarf
+  name: trait-dwarf-name
+  description: trait-dwarf-desc
+  category: Height
+  cost: 1
+  components:
+  - type: ScaleVisuals
+    scale: 1, 0.8
+  - type: FixturesReplace
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.30
+        # they r smaller
+        density: 120
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+      flammable:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.30
+        density: 1
+        restitution: 0.0
+        mask:
+        - 221
+        layer:
+        - 0
+       
+- type: trait
+  id: Short
+  name: trait-short-name
+  description: trait-short-desc
+  category: Height
+  cost: 1
+  components:
+  - type: ScaleVisuals
+    scale: 0.95, 0.95
+  - type: FixturesReplace
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.325
+        # they r small
+        density: 125
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+      flammable:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.325
+        density: 1
+        restitution: 0.0
+        mask:
+        - 221
+        layer:
+        - 0
+       
+- type: trait
+  id: Tall
+  name: trait-tall-name
+  description: trait-tall-desc
+  category: Height
+  cost: 1
+  components:
+  - type: ScaleVisuals
+    scale: 1.05, 1.05
+  - type: FixturesReplace
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.40
+        # they r bigger
+        density: 160
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+      flammable:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.40
+        density: 1
+        restitution: 0.0
+        mask:
+        - 221
+        layer:
+        - 0
+
+- type: trait
+  id: Huge
+  name: trait-huge-name
+  description: trait-huge-desc
+  category: Height
+  cost: 1
+  components:
+  - type: ScaleVisuals
+    scale: 1.10, 1.10
+  - type: FixturesReplace
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        # they r biggest
+        density: 200
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+      flammable:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 1
+        restitution: 0.0
+        mask:
+        - 221
+        layer:
+        - 0


### PR DESCRIPTION
<!-- Guidelines: TBD sorry. Sorry. I'm trying to fix it -->

## About the PR
You can be short, tall, big and small... And a dwarf. Yes, this uses ScaleVisuals.

## Why / Balance
Uhhh... Be small. Be big. People like doing that.

## Technical details
<!-- Summary of code changes for easier review. -->
Adds FixturesReplaceComponent. They are identical to FixturesChangeComponent, except it will replace a fixture if the fixture already exists, instead of doing nothing.

## Media
No media because I don't like you.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the Pull Request and Changelog Guidelines. <!-- SORRY WE DONT HAVE THIS ONE YET. SORRY -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: hereelabs
- add: Heights are now available in the traits menu.
